### PR TITLE
Updating axios and public-ips dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 package-lock.json
+.nyc_output
+coverage
+error.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "smartapi-javascript",
-	"version": "1.0.27",
+	"version": "1.0.28",
 	"description": "",
 	"main": "./lib/",
 	"scripts": {
@@ -15,14 +15,14 @@
 	"dependencies": {
 		"address": "^1.1.2",
 		"atob": "^2.1.2",
-		"axios": "^0.20.0",
+		"axios": "^1.9.0",
 		"binary-parser": "^2.2.1",
 		"chai": "^4.3.10",
 		"mocha": "^10.2.0",
 		"nyc": "^15.1.0",
 		"pako": "^2.1.0",
 		"proxyquire": "^2.1.3",
-		"public-ip": "^4.0.2",
+		"public-ip": "^7.0.1",
 		"querystring": "^0.2.0",
 		"sinon": "^17.0.1",
 		"winston": "^3.11.0",


### PR DESCRIPTION
Updating axios and public-ips dependency to fix the npm audit seen for the packages.
Also, modified gitignore to excluded error.log, .nyc_output & coverage folder from the commit