### PR TITLE
Updated axios and public-ip dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "address": "^1.1.2",
     "atob": "^2.1.2",
-    "axios": "^0.20.0",
+    "axios": "^1.9.0",
     "pako": "^2.0.0",
-    "public-ip": "^4.0.2",
+    "public-ip": "^7.0.1",
     "querystring": "^0.2.0",
     "ws": "^7.4.0"
   }


### PR DESCRIPTION
Updated axios and public ip dependency to fix npm audit issues.

```
npm audit report

axios  <=0.29.0
Severity: high
Axios vulnerable to Server-Side Request Forgery - https://github.com/advisories/GHSA-4w2v-q235-vp99
Axios Cross-Site Request Forgery Vulnerability - https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
axios Inefficient Regular Expression Complexity vulnerability - https://github.com/advisories/GHSA-cph5-m8f7-6c5x
axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL - https://github.com/advisories/GHSA-jr5f-v2jv-69x6
No fix available
node_modules/smartapi-javascript/node_modules/axios
  smartapi-javascript  *
  Depends on vulnerable versions of axios
  Depends on vulnerable versions of public-ip
  node_modules/smartapi-javascript

got  <11.8.5
Severity: moderate
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
fix available via `npm audit fix`
node_modules/got
  public-ip  2.1.0 - 4.0.4
  Depends on vulnerable versions of got
  node_modules/public-ip

4 vulnerabilities (2 moderate, 2 high)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.
```